### PR TITLE
Add a slider for Affine Mapping strength

### DIFF
--- a/src/MidnightPSXCustomGUI.cs
+++ b/src/MidnightPSXCustomGUI.cs
@@ -219,6 +219,13 @@ public class MidnightPSXCustomGUI : ShaderGUI
         MaterialProperty affine = FindProperty("_AffineMappingToggle");
         GUIContent affineLabel = MakeLabel("Enable Affine Mapping", "Emulates the texture warping seen in the original PSX");
         editor.ShaderProperty(affine, affineLabel);
+
+        if (affine.floatValue == 1)
+        {
+            MaterialProperty affineStrength = FindProperty("_AffineMappingStrength");
+            GUIContent affineStrengthLabel = MakeLabel("Affine Mapping Strength", "Controls the strength of the affine mapping effect");
+            editor.ShaderProperty(affineStrength, affineStrengthLabel);
+        }
     }
 
     void DoTexturePixelization()

--- a/src/MidnightPSXPolygons.shader
+++ b/src/MidnightPSXPolygons.shader
@@ -22,7 +22,8 @@ Shader "Custom PSX Shaders/Midnight PSX Polygons"
 
 		[Enum(PSX Point,0, PSX Bilinear,512, N64, 256, Saturn, 128,  LOD Close, 94, LOD Mid, 59, LOD Far, 17)] _Filtering ("Filtering Mode", int) = 0			 
 		
-		[Toggle] _AffineMappingToggle("Enable Affine Texture Mapping", float) = 0																				 
+		[Toggle] _AffineMappingToggle("Enable Affine Texture Mapping", float) = 0
+		[PowerSlider(2.0)]_AffineMappingStrength("Affine Mapping Strength", Range(0, 1)) = 1.0																				 
 
 		[Toggle] _PixelationToggle("Enable Texture Pixelization", float) = 0																					 
 		_PixelationFactor("Texture Resolution", float) = 1024																									 


### PR DESCRIPTION
Edits the MidnightPSX Pass, CustomGUI, and Polygons Shader to Lerp between a non-affine state and fully affine state with a slider that appears when the Affine Mapping is enabled.

Example:
<img width="858" height="286" alt="image" src="https://github.com/user-attachments/assets/0fe80550-98ae-4fe2-a0ce-490e0e27d778" />

Doing this means you can emulate more of the later games, which tried to mitigate this issue without having to do large subdivisions on the model. See explanation below:

"Later PS1 games tried to mitigate the warping effect of affine texture sampling by simply using subdivided geometry, which meant that these texture glitches happened on smaller triangles, and were therefore less noticeable."<sup>[1]</sup>

[1] - PlayStation 1 Affine Texture Mapping in Shader Code (https://danielilett.com/2021-11-06-tut5-21-ps1-affine-textures/)